### PR TITLE
feat: configure docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+npm-debug.log
+data/blm-campsites.json

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,40 @@
+name: Docker Build Test
+
+on:
+  pull_request:
+    paths:
+    - 'Dockerfile'
+    - '**/package.json'
+    - '**/package-lock.json'
+    - '.github/workflows/docker.yml'
+    - '**/*.ts'
+    - '**/*.js'
+    - '**/*.json'
+    - '**/*.yml'
+    - '**/*.yaml'
+  push:
+    branches:
+    - main
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build Docker image
+      run: docker build -t blm-spider .
+
+    - name: Test container starts
+      run: |
+        docker run -d --name blm-spider-test -p 8080:8080 blm-spider
+        sleep 10
+        docker ps | grep blm-spider-test
+
+    - name: Clean up
+      if: always()
+      run: docker rm -f blm-spider-

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: Docker Build Test
+name: Docker Build
 
 on:
   pull_request:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:22-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+
+RUN npm run build
+
+ENV NODE_ENV=production
+ENV PORT=8080
+
+EXPOSE 8080
+
+CMD ["node", "dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -219,3 +219,30 @@ This will crawl the BLM site and update `data/blm-campsites.json`.
 
 ### Schedule automatic updates
 A cron job is set up in `src/cron.ts` to run every week. 
+
+---
+
+## Docker
+
+You can run the BLM Spider API in a Docker container for easy deployment and isolation.
+
+### Build the Docker image
+
+```sh
+docker build -t blm-spider .
+```
+
+### Run the API server with Docker
+
+```sh
+docker run -p 8080:8080 -v $(pwd)/data:/app/data blm-spider
+```
+
+or using Docker Compose:
+
+```sh
+docker-compose up --build
+```
+
++ The API will be available at http://localhost:8080.
++ The -v $(pwd)/data:/app/data flag mounts your local data directory into the container, so the API can read and write blm-campsites.json.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.8"
+
+services:
+  api:
+    build: .
+    container_name: blm-spider-api
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./data:/app/data
+    environment:
+      - NODE_ENV=production
+      - PORT=8080
+    restart: unless-stopped


### PR DESCRIPTION
## Background

+ Added a Dockerfile to build and run the BLM Spider API in a containerized environment.
+ Updated the README with clear instructions for:
   + Building the Docker image.
   + Running the API server using Docker (docker run ...).
   + Using Docker Compose (docker-compose up --build) for easier setup.